### PR TITLE
Add Medium article to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BestPracticesApp
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 7.3.1.
+This project was created to demonstrate [5 Tips & Best Practices to Organize your Angular Project](https://medium.com/dev-jam/5-tips-best-practices-to-organize-your-angular-project-e900db08702e).
 
 ## Development server
 


### PR DESCRIPTION
I usually save just the repos of useful tutorials, but not the articles for them. I think it can be good for others too if there is a link for the tutorial in the repository.